### PR TITLE
Added additional operators to duration_t

### DIFF
--- a/src/GPStime.cpp
+++ b/src/GPStime.cpp
@@ -1341,6 +1341,11 @@ bool duration_t::operator==(const duration_t &other) const
   return _femtosecs == other._femtosecs;
 }
 
+bool duration_t::operator!=(const duration_t &other) const
+{
+  return !(*this == other);
+}
+
 bool duration_t::operator<(const duration_t &other) const
 {
   return _femtosecs < other._femtosecs;
@@ -1356,7 +1361,22 @@ duration_t duration_t::operator-(const duration_t& other) const
   return duration_t(_femtosecs - other._femtosecs);
 }
 
+duration_t duration_t::operator*(double other) const
+{
+  return duration_t(_femtosecs * other);
+}
+
+duration_t duration_t::operator*(femtosecs_t other) const
+{
+  return duration_t(_femtosecs * other);
+}
+
 duration_t duration_t::operator/(double other) const
+{
+  return duration_t(_femtosecs / other);
+}
+
+duration_t duration_t::operator/(femtosecs_t other) const
 {
   return duration_t(_femtosecs / other);
 }

--- a/src/GPStime.cpp
+++ b/src/GPStime.cpp
@@ -1152,6 +1152,18 @@ bool utc_time_t::operator<(const utc_time_t &other) const {
   }
 }
 
+bool utc_time_t::operator<=(const utc_time_t &other) const {
+  return *this == other || *this < other;
+}
+
+bool utc_time_t::operator>(const utc_time_t &other) const {
+  return other < *this;
+}
+
+bool utc_time_t::operator>=(const utc_time_t &other) const {
+  return *this == other || *this > other;
+}
+
 /** @brief The total number of femtoseconds in the duration */
 femtosecs_t duration_t::get_fs() const
 {
@@ -1349,6 +1361,21 @@ bool duration_t::operator!=(const duration_t &other) const
 bool duration_t::operator<(const duration_t &other) const
 {
   return _femtosecs < other._femtosecs;
+}
+
+bool duration_t::operator<=(const duration_t &other) const
+{
+  return *this == other || *this < other;
+}
+
+bool duration_t::operator>(const duration_t &other) const
+{
+  return other < *this;
+}
+
+bool duration_t::operator>=(const duration_t &other) const
+{
+  return *this == other || *this > other;
 }
 
 duration_t duration_t::operator+(const duration_t& other) const

--- a/src/femtotime/GPStime.hpp
+++ b/src/femtotime/GPStime.hpp
@@ -356,10 +356,14 @@ public:
 
   bool operator<(const duration_t &other) const;
   bool operator==(const duration_t &other) const;
+  bool operator!=(const duration_t &other) const;
 
   duration_t operator+(const duration_t &other) const;
   duration_t operator-(const duration_t &other) const;
+  duration_t operator*(double other) const;
+  duration_t operator*(femtosecs_t other) const;
   duration_t operator/(double other) const;
+  duration_t operator/(femtosecs_t other) const;
 
 private:
   femtosecs_t _femtosecs;

--- a/src/femtotime/GPStime.hpp
+++ b/src/femtotime/GPStime.hpp
@@ -241,6 +241,9 @@ public:
   bool operator !=(const utc_time_t &other) const;
 
   bool operator <(const utc_time_t &other) const;
+  bool operator <=(const utc_time_t &other) const;
+  bool operator >(const utc_time_t &other) const;
+  bool operator >=(const utc_time_t &other) const;
 
 private:
   // A quick note on the representation of leap seconds:
@@ -355,6 +358,9 @@ public:
   static duration_t from_timespec(struct timespec *ts);
 
   bool operator<(const duration_t &other) const;
+  bool operator<=(const duration_t &other) const;
+  bool operator>(const duration_t &other) const;
+  bool operator>=(const duration_t &other) const;
   bool operator==(const duration_t &other) const;
   bool operator!=(const duration_t &other) const;
 


### PR DESCRIPTION
This adds the following operators to duration_t:

```c++
bool operator!=(const duration_t &other) const;

duration_t operator*(double other) const;

duration_t operator*(femtosecs_t other) const;

duration_t operator/(femtosecs_t other) const;
```