### PR TITLE
Fixed build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,8 @@ msgpack_dep = dependency('msgpack', required : false)
 if msgpack_dep.found()
   add_project_arguments([
                          '-DHAVE_MSGPACK=1',
-                         ])
+                         ],
+                         language : 'cpp')
 endif
 all_deps = [fmt_dep, msgpack_dep]
 


### PR DESCRIPTION
Any call to `add_project_arguments` requires a `language` field in it. One call to this function was missing, so Meson would refuse to compile whenever it found an install of msgpack.